### PR TITLE
Trigger an Adhearsion Event on Inactive Calls

### DIFF
--- a/lib/adhearsion/punchblock_plugin/initializer.rb
+++ b/lib/adhearsion/punchblock_plugin/initializer.rb
@@ -145,6 +145,7 @@ module Adhearsion
             call.async.deliver_message event
           else
             logger.error "Event received for inactive call #{event.target_call_id}: #{event.inspect}"
+            Events.trigger :inactive_call, event
           end
         end
 

--- a/spec/adhearsion/punchblock_plugin/initializer_spec.rb
+++ b/spec/adhearsion/punchblock_plugin/initializer_spec.rb
@@ -280,6 +280,11 @@ module Adhearsion
             Adhearsion::Logging.get_logger(Initializer).should_receive(:error).once.with("Event received for inactive call #{call_id}: #{mock_event.inspect}")
             Initializer.dispatch_call_event mock_event
           end
+
+          it "should trigger an inactive call event" do
+            Events.instance.should_receive(:trigger).once.with(:inactive_call, mock_event)
+            Initializer.dispatch_call_event mock_event
+          end
         end
       end
 


### PR DESCRIPTION
If an Event is received for an inactive call, currently Adhearsion will log an error message but provides no mechanism for reporting an exception [e.g, triggering an Airbrake or Email in our case]. This change triggers a new event type, **inactive_call** that can be tapped into from Phoenix.

@sfgeorge 

cc: @rsuddeth 
