### PR TITLE
2.4 Inactive Call Event Changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'activesupport', '~> 3.0' if RUBY_VERSION == "1.9.2"
+
+gem 'punchblock', :git => 'git@github.com:cloudvox/punchblock.git', :ref => 'develop-ifbyphone'
+gem 'celluloid', :git => 'git@github.com:cloudvox/celluloid.git', :ref => 'develop-dialogtech'

--- a/lib/adhearsion/punchblock_plugin/initializer.rb
+++ b/lib/adhearsion/punchblock_plugin/initializer.rb
@@ -145,6 +145,7 @@ module Adhearsion
             call.async.deliver_message event
           else
             logger.error "Event received for inactive call #{event.target_call_id}: #{event.inspect}"
+            Events.trigger :inactive_call, event
           end
         end
 

--- a/spec/adhearsion/punchblock_plugin/initializer_spec.rb
+++ b/spec/adhearsion/punchblock_plugin/initializer_spec.rb
@@ -280,6 +280,11 @@ module Adhearsion
             Adhearsion::Logging.get_logger(Initializer).should_receive(:error).once.with("Event received for inactive call #{call_id}: #{mock_event.inspect}")
             Initializer.dispatch_call_event mock_event
           end
+
+          it "should trigger an inactive call event" do
+            Events.instance.should_receive(:trigger).once.with(:inactive_call, mock_event)
+            Initializer.dispatch_call_event mock_event
+          end
         end
       end
 


### PR DESCRIPTION
Porting of support for inactive call events over to the direct 2.4 fork of Adhearsion that was created.

@sfgeorge Shiny new review for you

cc: @rsuddeth 
