### PR TITLE
[FEATURE] adding controller-specific metadata to #split

### DIFF
--- a/lib/adhearsion/call_controller/dial.rb
+++ b/lib/adhearsion/call_controller/dial.rb
@@ -224,8 +224,10 @@ module Adhearsion
         # Optionally executes call controllers on calls once split, where 'current_dial' is available in controller metadata in order to perform further operations on the Dial, including rejoining and termination.
         # @param [Hash] targets Target call controllers to execute on call legs once split
         # @option options [Adhearsion::CallController] :main The call controller class to execute on the 'main' call leg (the one who initiated the #dial)
+        # @option options [Hash] :main_metadata Metadata to set on the :main controller before executing it
         # @option options [Proc] :main_callback A block to call when the :main controller completes
         # @option options [Adhearsion::CallController] :others The call controller class to execute on the 'other' call legs (the ones created as a result of the #dial)
+        # @option options [Hash] :others_metadata Metadata to set on the :others controller before executing it
         # @option options [Proc] :others_callback A block to call when the :others controller completes on an individual call
         def split(targets = {})
           @splitting = true
@@ -235,16 +237,21 @@ module Adhearsion
             end
           end.compact
           logger.info "Splitting off peer calls #{calls_to_split.map(&:first).join ", "}"
+          controller_metadata = {'current_dial' => self}
+          others_metadata = controller_metadata.clone
+          others_metadata.merge!(targets[:others_metadata]) if targets.key? :others_metadata
           calls_to_split.each do |id, call|
             ignoring_ended_calls do
               logger.debug "Unjoining peer #{call.id} from #{join_target}"
               ignoring_missing_joins { call.unjoin join_target }
               if split_controller = targets[:others]
                 logger.info "Executing controller #{split_controller} on split call #{call.id}"
-                call.execute_controller split_controller.new(call, 'current_dial' => self), targets[:others_callback]
+                call.execute_controller split_controller.new(call, others_metadata), targets[:others_callback]
               end
             end
           end
+          main_metadata = controller_metadata.clone
+          main_metadata.merge!(targets[:main_metadata]) if targets.key? :main_metadata
           ignoring_ended_calls do
             if join_target != @call
               logger.debug "Unjoining main call #{@call.id} from #{join_target}"
@@ -252,7 +259,7 @@ module Adhearsion
             end
             if split_controller = targets[:main]
               logger.info "Executing controller #{split_controller} on main call"
-              @call.execute_controller split_controller.new(@call, 'current_dial' => self), targets[:main_callback]
+              @call.execute_controller split_controller.new(@call, main_metadata), targets[:main_callback]
             end
           end
         end

--- a/spec/adhearsion/call_controller/dial_spec.rb
+++ b/spec/adhearsion/call_controller/dial_spec.rb
@@ -1917,6 +1917,82 @@ module Adhearsion
                 waiter_thread.join
                 expect(dial.status.result).to eq(:answer)
               end
+
+              shared_examples_for 'split call' do
+                it do
+                  expect(call['hit_split_controller']).to eq(main_split_controller)
+                  expect(call['split_controller_metadata']['current_dial']).to be @dial
+                  expect(call['split_controller_metadata']['apple']).to eq expected_main_value
+                  expect(call['split_controller_metadata'].except('current_dial')).to eq expected_additional_main_metadata
+
+                  expect(other_mock_call['hit_split_controller']).to eq(others_split_controller)
+                  expect(other_mock_call['split_controller_metadata']['current_dial']).to be @dial
+                  expect(other_mock_call['split_controller_metadata']['orange']).to eq expected_others_value
+                  expect(other_mock_call['split_controller_metadata'].except('current_dial')).to eq expected_additional_others_metadata
+                end
+              end
+
+              context "should pass :main_metadata and :others_metadata on respective controllers", focus: true do
+                let(:split_parameters) {{main: main_split_controller, others: others_split_controller, main_callback: ->(call) {self.callback(call)}, others_callback: ->(call) {self.callback(call)}}}
+                let(:main_metadata) {{'apple' => {'color' => 'red'}}}
+                let(:others_metadata) {{'orange' => {'shape' => 'sphere'}}}
+
+                before :each do
+                  @dial = Dial::ParallelConfirmationDial.new to, options, call
+                  @dial.run subject
+
+                  @waiter_thread = Thread.new do
+                    @dial.await_completion
+                    latch.countdown!
+                  end
+
+                  sleep 0.5
+
+                  other_mock_call << mock_answered
+
+                  expect(self).to receive(:callback).once.with(call)
+                  expect(self).to receive(:callback).once.with(other_mock_call)
+
+                  @dial.split example_split_parameters
+
+                  expect(latch.wait(2)).to be_falsey
+                  expect(split_latch.wait(2)).to be_truthy
+
+                  other_mock_call << mock_end
+
+                  expect(latch.wait(2)).to be_truthy
+
+                  @waiter_thread.join
+                  expect(@dial.status.result).to eq(:answer)
+                end
+
+                context 'without additional controller metadata' do
+                  let(:example_split_parameters) {split_parameters}
+                  let(:expected_main_value) {nil}
+                  let(:expected_others_value) {nil}
+                  let(:expected_additional_main_metadata) {{}}
+                  let(:expected_additional_others_metadata) {{}}
+                  it_behaves_like 'split call'
+                end
+
+                context 'with additional controller metadata on main controller' do
+                  let(:example_split_parameters) {split_parameters.merge(main_metadata: main_metadata)}
+                  let(:expected_main_value) {main_metadata['apple']}
+                  let(:expected_others_value) {nil}
+                  let(:expected_additional_main_metadata) {main_metadata}
+                  let(:expected_additional_others_metadata) {{}}
+                  it_behaves_like 'split call'
+                end
+
+                context 'with additional controller metadata on others controllers' do
+                  let(:example_split_parameters) {split_parameters.merge(others_metadata: others_metadata)}
+                  let(:expected_main_value) {nil}
+                  let(:expected_others_value) {others_metadata['orange']}
+                  let(:expected_additional_main_metadata) {{}}
+                  let(:expected_additional_others_metadata) {others_metadata}
+                  it_behaves_like 'split call'
+                end
+              end
             end
 
             context "when rejoining" do


### PR DESCRIPTION
attn @sfgeorge, @lpradovera

Adding support for controller-specific metadata during Dial#split, to facilitate passing parameters to the :main and :others call controllers.

Implementation of: https://dialogtech.atlassian.net/browse/DTPORTAL-5676