### PR TITLE
[FEATURE] yielding dial object during #dial and #dial_and_confirm

### DIFF
--- a/lib/adhearsion/call_controller/dial.rb
+++ b/lib/adhearsion/call_controller/dial.rb
@@ -46,6 +46,8 @@ module Adhearsion
       #
       # @option options [Array, #call] :ringback A collection of audio (see #play for acceptable values) to render as a replacement for ringback. If a callback is passed, it will be used to start ringback, and must return something that responds to #stop! to stop it.
       #
+      # @yield [Adhearsion::CallController::Dial::Dial] Provides the newly initialized Dial object to the given block, particularly useful in order to obtain a reference to it for later use.
+      #
       # @example Make a call to the PSTN using my SIP provider for VoIP termination
       #   dial "SIP/19095551001@my.sip.voip.terminator.us"
       #
@@ -59,6 +61,7 @@ module Adhearsion
       #
       def dial(to, options = {})
         dial = Dial.new to, options, call
+        yield dial if block_given?
         dial.run(self)
         dial.await_completion
         dial.terminate_ringback
@@ -73,9 +76,12 @@ module Adhearsion
       #
       # @option options [CallController] :apology controller to execute on calls which lose the race to complete confirmation before they are hung up
       #
+      # @yield [Adhearsion::CallController::Dial::ParallelConfirmationDial] Provides the newly initialized ParallelConfirmationDial object to the given block, particularly useful in order to obtain a reference to it for later use.
+      #
       # @see #dial
       def dial_and_confirm(to, options = {})
         dial = ParallelConfirmationDial.new to, options, call
+        yield dial if block_given?
         dial.run(self)
         dial.await_completion
         dial.terminate_ringback

--- a/spec/adhearsion/call_controller/dial_spec.rb
+++ b/spec/adhearsion/call_controller/dial_spec.rb
@@ -1447,6 +1447,17 @@ module Adhearsion
             end
           end
         end
+
+        context 'when given a block with one argument' do
+          it "yields a block on the dial obj" do
+            expect(OutboundCall).to receive(:new).and_return other_mock_call
+            expect(other_mock_call).to receive(:dial).with(to, options).once
+            Thread.new do
+              expect {|b| subject.dial(to, options, &b)}.to yield_with_args Dial
+            end
+            sleep 0.1
+          end
+        end
       end
 
       describe "#dial_and_confirm" do
@@ -2824,6 +2835,17 @@ module Adhearsion
                 expect(status.joins[second_other_mock_call].result).to eq(:lost_confirmation)
               end
             end
+          end
+        end
+
+        context 'when given a block with one argument' do
+          it "yields a block on the dial obj" do
+            expect(OutboundCall).to receive(:new).and_return other_mock_call
+            expect(other_mock_call).to receive(:dial).with(to, options).once
+            Thread.new do
+              expect {|b| subject.dial_and_confirm(to, options, &b)}.to yield_with_args ParallelConfirmationDial
+            end
+            sleep 0.1
           end
         end
       end


### PR DESCRIPTION
attn @sfgeorge, @lpradovera

Yielding the newly initialized dial object during `dial` and `dial_and_confirm`, primarily so that we can access the dial object later for subsequent calls to `split` and `rejoin`.

Implementation of: https://dialogtech.atlassian.net/browse/DTPORTAL-5675