### PR TITLE
DTRPOTAL-9535: drop jruby openssl from gemspec

### DIFF
--- a/adhearsion.gemspec
+++ b/adhearsion.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'ffi', ["~> 1.0"]
   s.add_runtime_dependency 'girl_friday'
   s.add_runtime_dependency 'has-guarded-handlers', ["~> 1.6"]
-  s.add_runtime_dependency 'jruby-openssl' if RUBY_PLATFORM == 'java'
   s.add_runtime_dependency 'logging', ["~> 2.0"]
   s.add_runtime_dependency 'pry'
   s.add_runtime_dependency 'punchblock', ["~> 2.6"]


### PR DESCRIPTION
Requiring jruby-openssl is an application's job, not the library's.

Prevents this funness when trying to bundle update from an adhearsion application using jruby-1.7.x:

```
Bundler could not find compatible versions for gem "jruby-openssl":
  In Gemfile:
    jruby-openssl (= 0.9.21) java

    adhearsion was resolved to 2.6.1, which depends on
      jruby-openssl
```