### PR TITLE
DTPORTAL-16140 [BUGFIX] Prevent quick Asterisk commands from hanging indefinitely

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ jdk:
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - rvm: jruby-9.2.5.0
 env: ARUBA_TIMEOUT=120 AHN_ENV=development JRUBY_OPTS="-J-Xmx512m"
 sudo: false
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,16 @@ rvm:
   - jruby-9.1.17.0
   - jruby-9.2.5.0
   - ruby-head
+  - jruby-head
 jdk:
   - openjdk8 # for jruby
+before_install:
+  - rvm @global @default do gem uninstall bundler -a -x --silent || true
+  - gem install bundler -v '<2'
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - rvm: jruby-head
     - rvm: jruby-9.2.5.0
 env: ARUBA_TIMEOUT=120 AHN_ENV=development JRUBY_OPTS="-J-Xmx512m"
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: ruby
 rvm:
   - 2.3.7
   - 2.4.4
+  - 2.5.3
   - jruby-9.1.17.0
+  - jruby-9.2.5.0
   - ruby-head
 jdk:
   - openjdk8 # for jruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
 jdk:
   - openjdk8 # for jruby
 before_install:
+  - ruby -v # for (j)ruby-head
   - rvm @global @default do gem uninstall bundler -a -x --silent || true
   - gem install bundler -v '<2'
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jdk:
 matrix:
   allow_failures:
     - rvm: ruby-head
-env: ARUBA_TIMEOUT=120 AHN_ENV=development JRUBY_OPTS="--server -J-Xss1024k -J-Xmx652m -J-XX:+UseConcMarkSweepGC"
+env: ARUBA_TIMEOUT=120 AHN_ENV=development JRUBY_OPTS="-J-Xmx512m"
 sudo: false
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 2.4.4
   - 2.5.3
   - jruby-9.1.17.0
-  - jruby-9.2.5.0
+  - jruby-9.2.6.0
   - ruby-head
   - jruby-head
 jdk:
@@ -17,7 +17,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    - rvm: jruby-9.2.5.0
+    - rvm: jruby-9.2.6.0 # fails console launching features (ChildProcess::TimeoutError) 
 env: ARUBA_TIMEOUT=120 AHN_ENV=development JRUBY_OPTS="-J-Xmx512m"
 sudo: false
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
 rvm:
-  - 2.3.7
-  - 2.4.4
-  - 2.5.3
+  - 2.3.8
+  - 2.4.6
+  - 2.5.5
   - jruby-9.1.17.0
-  - jruby-9.2.6.0
+  - jruby-9.2.7.0
   - ruby-head
   - jruby-head
 jdk:
@@ -17,7 +17,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    - rvm: jruby-9.2.6.0 # fails console launching features (ChildProcess::TimeoutError) 
+    - rvm: jruby-9.2.7.0 # fails console launching features (ChildProcess::TimeoutError)
 env: ARUBA_TIMEOUT=120 AHN_ENV=development JRUBY_OPTS="-J-Xmx512m"
 sudo: false
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Bugfix: Shuts down a call which couldn't be routed with a fake end event. This avoids leaking call actors in cases where the call ended before it was dispatched and we missed the real End event.
   * Bugfix: Removes proactive checks on call availability before dispatching events because these are inaccurate; now optimistically dispatches.
   * Bugfix: Don't trigger the exception event handler twice per exception
+  * Bugfix: Prevent quick Asterisk commands from hanging indefinitely by registering components before executing them.
   * Change: `Adhearsion::Call#start_time` now consistently tracks the call start time for both incoming and outgoing calls
   * Feature: Add `Adhearsion::Call#answer_time` to track the time at which the call was answered
   * Feature: Send `Adhearsion::Event::Answered` events when inbound calls are answered (formerly was only sent when outbound calls were answered)

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,10 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'sinatra', require: nil
+
+group :test do
+  # TODO: some expectations started failing in 3.8.3
+  # The be_a_kind_of matcher requires that the actual object responds to either
+  # #kind_of? or #is_a? methods  but it responds to neigher of two methods.
+  gem 'rspec-expectations', '< 3.8.3'
+end

--- a/adhearsion.gemspec
+++ b/adhearsion.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activesupport', [">= 3.0.0", "< 5.0.0"]
   s.add_runtime_dependency 'adhearsion-loquacious', ["~> 1.9"]
   s.add_runtime_dependency 'blather', ["~> 2.0"]
-  s.add_runtime_dependency 'bundler', ["~> 1.0"]
   s.add_runtime_dependency 'celluloid', ["~> 0.16.0"]
   s.add_runtime_dependency 'countdownlatch'
   s.add_runtime_dependency 'deep_merge'

--- a/adhearsion.gemspec
+++ b/adhearsion.gemspec
@@ -53,4 +53,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'guard-yard'
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'timecop'
+  s.add_development_dependency 'nio4r', "< 2.4.0"
 end

--- a/adhearsion.gemspec
+++ b/adhearsion.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'cucumber'
   s.add_development_dependency 'guard-cucumber'
   s.add_development_dependency 'guard-rspec'
-  s.add_development_dependency 'rspec', ["~> 3.0"]
+  s.add_development_dependency 'rspec', ["~> 3.8"]
   s.add_development_dependency 'yard'
   s.add_development_dependency 'guard-yard'
   s.add_development_dependency 'coveralls'

--- a/lib/adhearsion/rayo/component/component_node.rb
+++ b/lib/adhearsion/rayo/component/component_node.rb
@@ -43,12 +43,14 @@ module Adhearsion
 
         def response=(other)
           @mutex.synchronize do
-            if other.is_a?(Ref)
-              @component_id = other.component_id
-              @source_uri = other.uri.to_s
-              client.register_component self if client
-            end
+            internal_register_ref other if other.is_a?(Ref)
             super
+          end
+        end
+
+        def register_ref(ref)
+          @mutex.synchronize do
+            internal_register_ref ref
           end
         end
 
@@ -83,6 +85,14 @@ module Adhearsion
         def stop!(options = {})
           raise InvalidActionError, "Cannot stop a #{self.class.name.split("::").last} that is #{state}" unless executing?
           stop_action.tap { |action| write_action action }
+        end
+
+        private
+
+        def internal_register_ref(ref)
+          @component_id = ref.component_id
+          @source_uri = ref.uri.to_s
+          client.register_component self if client
         end
       end
     end

--- a/lib/adhearsion/translator/asterisk/component.rb
+++ b/lib/adhearsion/translator/asterisk/component.rb
@@ -64,6 +64,10 @@ module Adhearsion
             set_node_response Adhearsion::Rayo::Ref.new uri: id
           end
 
+          def register_ref
+            @component_node.register_ref Adhearsion::Rayo::Ref.new uri: id
+          end
+
           def with_error(name, text)
             set_node_response Adhearsion::ProtocolError.new.setup(name, text)
           end

--- a/lib/adhearsion/translator/asterisk/component/asterisk/agi_command.rb
+++ b/lib/adhearsion/translator/asterisk/component/asterisk/agi_command.rb
@@ -11,8 +11,9 @@ module Adhearsion
             end
 
             def execute
-              send_ref
+              register_ref
               @agi.execute ami_client
+              send_ref
             rescue RubyAMI::Error
               set_node_response false
             rescue ChannelGoneError

--- a/lib/adhearsion/translator/asterisk/component/asterisk/agi_command.rb
+++ b/lib/adhearsion/translator/asterisk/component/asterisk/agi_command.rb
@@ -11,8 +11,8 @@ module Adhearsion
             end
 
             def execute
-              @agi.execute ami_client
               send_ref
+              @agi.execute ami_client
             rescue RubyAMI::Error
               set_node_response false
             rescue ChannelGoneError

--- a/spec/adhearsion/call_controller/dial_spec.rb
+++ b/spec/adhearsion/call_controller/dial_spec.rb
@@ -1491,23 +1491,24 @@ module Adhearsion
             expect(other_mock_call).to receive(:dial).with(to, options).once
             expect(OutboundCall).to receive(:new).and_return other_mock_call
           end
+          let(:options) { { timeout: 1.0 } }
           let(:yield_latch) { CountDownLatch.new 1 }
           let(:thread_latch) { CountDownLatch.new 1 }
 
           it 'yields a block on the dial obj' do
+            @dial_obj = Concurrent::AtomicReference.new
             my_dial_block = proc do |dial|
-              @dial_obj = dial
+              @dial_obj.set dial
               yield_latch.countdown!
             end
             Thread.new do
               subject.dial to, options, &my_dial_block
               thread_latch.countdown!
             end
-            expect(yield_latch.wait(2)).to be_truthy
-            expect(@dial_obj).to be_instance_of Dial::Dial
-            other_mock_call << mock_answered
+            expect(yield_latch.count.zero? || yield_latch.wait(1)).to be_truthy
+            expect(@dial_obj.get).to be_instance_of Dial::Dial
             other_mock_call << mock_end
-            expect(thread_latch.wait(2)).to be_truthy
+            expect(thread_latch.count.zero? || thread_latch.wait(2)).to be_truthy
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,8 +58,7 @@ RSpec.configure do |config|
 end
 
 Adhearsion::Events.exception do |e, _|
-  puts e.message
-  puts e.backtrace.join("\n")
+  warn "#{e.inspect}\n  #{(e.backtrace || ['NO BACKTRACE']).join("\n  ")}"
 end
 
 # Test modules for #mixin methods

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,7 +57,7 @@ RSpec.configure do |config|
   end
 end
 
-Adhearsion::Events.exception do |e|
+Adhearsion::Events.exception do |e, _|
   puts e.message
   puts e.backtrace.join("\n")
 end


### PR DESCRIPTION
[DTPORTAL-16140 \[PHX\] Call hang after IVR Recording question](https://dialogtech.atlassian.net/browse/DTPORTAL-16140)

### [BUGFIX] Prevent quick Asterisk commands from hanging indefinitely by registering components before executing them.

We got stuck on a mysterious issue with calls indefinitely hanging during adhearsion-asterisk `#execute` commands that return quickly, including:
* `execute 'Monitor'`
* `execute 'StopMonitor'`
* `variable :WAITSTATUS`

The good news is that now I think we have both an understanding of its cause & the resolution.

#### Symptom
* An adhearsion-asterisk #execute would hang indefinitely sometimes here (https://github.com/adhearsion/adhearsion/blob/3.0.0.rc1/lib/adhearsion/call_controller.rb#L231).  Specifically, for those commands that start & finish quickly within just a few milliseconds.

#### Cause:
• When the Adhearsion::Event::Complete is created and intended to be routed to the related Component, sometimes there would be no known component (`event.source`) to route the event to.  In this if-else block (https://github.com/adhearsion/adhearsion/blob/3.0.0.rc1/lib/adhearsion/rayo/client.rb#L26-L30) when we are in the adverse case , instead of going to the intended “if” branch we would quietly route to the “else”, causing the event not to notify the Component - which was really bad.
• Why does this happen sometimes?  Because in order to be able to find the Component via `event.source`, we have to first `register_component` so that `client.find_component_by_uri` can succeed .(https://github.com/adhearsion/adhearsion/blob/3.0.0.rc1/lib/adhearsion/rayo/rayo_node.rb#L91)  And for some odd reason Adhearsion (and even for a long time previously Punchblock as far back as https://github.com/adhearsion/punchblock/commit/a3c36eaa1#diff-823037bc3e2e67ac9694ed54212f5b1eL17 v1.9.0 / May 3, 2013) agi_command executions would first 2. send their commands out to Asterisk asynchronously, and _then_ 1. `register_component` :arrows_counterclockwise: :no_good: :x: .  It was a daring race game to see who could finish fastest.  For some reason, we’ve not noticeably lost this race until recently - but I believe that the conditions setup way back here have always been invalid, especially since other places do things properly `1. send_ref`, then `2. execute_component` (e.g. https://github.com/adhearsion/adhearsion/blob/3.0.0.rc1/lib/adhearsion/translator/asterisk/component/asterisk/ami_action.rb#L17-L18) :white_check_mark:

