### PR TITLE
DTPORTAL-16140 [BUGFIX] Prevent quick Asterisk commands from hanging indefinitely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Bugfix: Shuts down a call which couldn't be routed with a fake end event. This avoids leaking call actors in cases where the call ended before it was dispatched and we missed the real End event.
   * Bugfix: Removes proactive checks on call availability before dispatching events because these are inaccurate; now optimistically dispatches.
   * Bugfix: Don't trigger the exception event handler twice per exception
+  * Bugfix: Prevent quick Asterisk commands from hanging indefinitely by registering components before executing them.
   * Change: `Adhearsion::Call#start_time` now consistently tracks the call start time for both incoming and outgoing calls
   * Feature: Add `Adhearsion::Call#answer_time` to track the time at which the call was answered
   * Feature: Send `Adhearsion::Event::Answered` events when inbound calls are answered (formerly was only sent when outbound calls were answered)

--- a/lib/adhearsion/rayo/component/component_node.rb
+++ b/lib/adhearsion/rayo/component/component_node.rb
@@ -43,12 +43,14 @@ module Adhearsion
 
         def response=(other)
           @mutex.synchronize do
-            if other.is_a?(Ref)
-              @component_id = other.component_id
-              @source_uri = other.uri.to_s
-              client.register_component self if client
-            end
+            internal_register_ref other if other.is_a?(Ref)
             super
+          end
+        end
+
+        def register_ref(ref)
+          @mutex.synchronize do
+            internal_register_ref ref
           end
         end
 
@@ -92,6 +94,13 @@ module Adhearsion
           super
         end
 
+        private
+
+        def internal_register_ref(ref)
+          @component_id = ref.component_id
+          @source_uri = ref.uri.to_s
+          client.register_component self if client
+        end
       end
     end
   end

--- a/lib/adhearsion/translator/asterisk/component.rb
+++ b/lib/adhearsion/translator/asterisk/component.rb
@@ -64,6 +64,10 @@ module Adhearsion
             set_node_response Adhearsion::Rayo::Ref.new uri: id
           end
 
+          def register_ref
+            @component_node.register_ref Adhearsion::Rayo::Ref.new uri: id
+          end
+
           def with_error(name, text)
             set_node_response Adhearsion::ProtocolError.new.setup(name, text)
           end

--- a/lib/adhearsion/translator/asterisk/component/asterisk/agi_command.rb
+++ b/lib/adhearsion/translator/asterisk/component/asterisk/agi_command.rb
@@ -11,8 +11,9 @@ module Adhearsion
             end
 
             def execute
-              send_ref
+              register_ref
               @agi.execute ami_client
+              send_ref
             rescue RubyAMI::Error
               set_node_response false
             rescue ChannelGoneError

--- a/lib/adhearsion/translator/asterisk/component/asterisk/agi_command.rb
+++ b/lib/adhearsion/translator/asterisk/component/asterisk/agi_command.rb
@@ -11,8 +11,8 @@ module Adhearsion
             end
 
             def execute
-              @agi.execute ami_client
               send_ref
+              @agi.execute ami_client
             rescue RubyAMI::Error
               set_node_response false
             rescue ChannelGoneError


### PR DESCRIPTION
[DTPORTAL-16140 \[PHX\] Call hang after IVR Recording question](https://dialogtech.atlassian.net/browse/DTPORTAL-16140)

### [BUGFIX] Prevent quick Asterisk commands from hanging indefinitely by registering components before executing them.

We got stuck on a mysterious issue with calls indefinitely hanging during adhearsion-asterisk `#execute` commands that return quickly, including:
* `execute 'Monitor'`
* `execute 'StopMonitor'`
* `variable :WAITSTATUS`

The good news is that now I think we have both an understanding of its cause & the resolution.

#### Symptom
* An adhearsion-asterisk #execute would hang indefinitely sometimes here (https://github.com/adhearsion/adhearsion/blob/3.0.0.rc1/lib/adhearsion/call_controller.rb#L231).  Specifically, for those commands that start & finish quickly within just a few milliseconds.

#### Cause:
• When the Adhearsion::Event::Complete is created and intended to be routed to the related Component, sometimes there would be no known component (`event.source`) to route the event to.  In this if-else block (https://github.com/adhearsion/adhearsion/blob/3.0.0.rc1/lib/adhearsion/rayo/client.rb#L26-L30) when we are in the adverse case , instead of going to the intended “if” branch we would quietly route to the “else”, causing the event not to notify the Component - which was really bad.
• Why does this happen sometimes?  Because in order to be able to find the Component via `event.source`, we have to first `register_component` so that `client.find_component_by_uri` can succeed .(https://github.com/adhearsion/adhearsion/blob/3.0.0.rc1/lib/adhearsion/rayo/rayo_node.rb#L91)  And for some odd reason Adhearsion (and even for a long time previously Punchblock as far back as https://github.com/adhearsion/punchblock/commit/a3c36eaa1#diff-823037bc3e2e67ac9694ed54212f5b1eL17 v1.9.0 / May 3, 2013) agi_command executions would first 2. send their commands out to Asterisk asynchronously, and _then_ 1. `register_component` :arrows_counterclockwise: :no_good: :x: .  It was a daring race game to see who could finish fastest.  For some reason, we’ve not noticeably lost this race until recently - but I believe that the conditions setup way back here have always been invalid, especially since other places do things properly `1.` register component, then `2. execute_component` (e.g. https://github.com/adhearsion/adhearsion/blob/3.0.0.rc1/lib/adhearsion/translator/asterisk/component/asterisk/ami_action.rb#L17-L18) :white_check_mark:
