### PR TITLE
Document that #execute_agi_command returns nil upon hangup

### DIFF
--- a/lib/adhearsion/translator/asterisk/call.rb
+++ b/lib/adhearsion/translator/asterisk/call.rb
@@ -309,7 +309,7 @@ module Adhearsion
         end
 
         #
-        # @return [Hash] AGI result
+        # @return [Hash, nil] AGI result, or nil if it is detected that the call is hung up.
         #
         # @raises RubyAMI::Error, ChannelGoneError
         def execute_agi_command(command, *params)

--- a/spec/adhearsion/translator/asterisk/call_spec.rb
+++ b/spec/adhearsion/translator/asterisk/call_spec.rb
@@ -2064,6 +2064,25 @@ module Adhearsion
                 expect(fut.value).to eq({code: 200, result: 123, data: 'timeout'})
               end
             end
+
+            context 'of type Hangup' do
+              let :ami_event do
+                RubyAMI::Event.new 'Hangup',
+                  'Uniqueid'      => "1320842458.8",
+                  'Calleridnum'   => "5678",
+                  'Calleridname'  => "Jane Smith",
+                  'Cause'         => '16',
+                  'Cause-txt'     => 'Normal Clearing',
+                  'Channel'       => "SIP/1234-00000000"
+              end
+
+              it 'should return nil' do
+                fut = Celluloid::Future.new { subject.execute_agi_command 'EXEC ANSWER' }
+                sleep 0.25
+                subject.process_ami_event ami_event
+                expect(fut.value).to be_nil
+              end
+            end
           end
 
           describe 'when receiving an Asterisk 13 AsyncAGIExec event' do


### PR DESCRIPTION
Document a [protection that our fork has to ensure that hungup calls correctly send a nil event](https://github.com/cloudvox/adhearsion/blob/8c6c81db8717a420bf5e203432a8c9cc392398a9/lib/adhearsion/translator/asterisk/call.rb#L365) in order to cause `#execute_agi_command` to end.

This duplicates what was done in #20, but no longer associates it with a DTPORTAL story so that it is not a blocker for release.